### PR TITLE
Avoid json_decode to cast large integers as floats

### DIFF
--- a/src/Mailjet/Response.php
+++ b/src/Mailjet/Response.php
@@ -39,7 +39,7 @@ class Response
 
         if ($response) {
             $this->status = $response->getStatusCode();
-            $this->body = json_decode($response->getBody(), true);
+            $this->body = json_decode($response->getBody(), true, 512, JSON_BIGINT_AS_STRING);
             $this->success = floor($this->status / 100) == 2 ? true : false;
         }
     }


### PR DESCRIPTION
I was having problems querying for sent messages because the ID I was saving was not in the correct format. Searching around I have found out that the issue is related with the cast that json_decode function does when returning a big integer value.
